### PR TITLE
Feat 43/negative middle timestamp

### DIFF
--- a/src/constants/commands.py
+++ b/src/constants/commands.py
@@ -46,7 +46,7 @@ HELP_MESSAGE: str = f'''
 
 {{{MIDDLE}}}
     + edit from [ start ] to [ end ]
-    + start and end are the form [ natural number | timestamp in form <[hour]-min-sec> ]
+    + start and end are the form [ integer | timestamp in form <[hour]-min-sec> ]
     + {NAME_FORMAT}
 
 {{{WHOLE}}}

--- a/src/helpers/video.py
+++ b/src/helpers/video.py
@@ -1,0 +1,36 @@
+import re
+import subprocess
+
+import helpers.time_handlers as time_handlers
+
+
+def convert_integer_seconds_to_natural_number(seconds: str,
+                                              duration: int) -> int:
+    raw_seconds = time_handlers.get_seconds(seconds)
+    return duration - raw_seconds if seconds.startswith('-') \
+        else raw_seconds
+
+
+def get_duration(joined_src_path: str) -> int:
+    args = [
+        'ffprobe',
+        '-i',
+        joined_src_path,
+        '-v',
+        'quiet',
+        '-show_entries',
+        'format=duration',
+        '-hide_banner',
+        '-of',
+        'default=noprint_wrappers=1:nokey=1'
+    ]
+    result = subprocess.run(args, capture_output=True, text=True)
+    return round_float(result.stdout)
+
+
+def round_float(float_string: str) -> int:
+    match = re.match(r'([(0-9)]+)\.([0-9])', float_string)
+    if match is None:
+        raise ValueError(f'could not round the time: {float_string}')
+    whole_number, tenths = int(match.group(1)), int(match.group(2))
+    return whole_number + (tenths >= 5)

--- a/src/lib/edit.py
+++ b/src/lib/edit.py
@@ -9,8 +9,9 @@ import constants.treatment_format as treatment_format
 import constants.video_editing as video_editing
 
 import helpers.files as files
-import helpers.video_paths as video_paths
 import helpers.time_handlers as time_handlers
+import helpers.video as video
+import helpers.video_paths as video_paths
 
 
 def treat_all(data: dict,
@@ -65,6 +66,21 @@ def edit_video(
         use_moviepy: bool, moviepy_threads: int,
         joined_src_path: str, joined_dst_path: str,
         start: None | str, end: None | str):
+
+    duration = video.get_duration(joined_src_path)
+    if start is not None:
+        start = str(
+            video.convert_integer_seconds_to_natural_number(
+                start, duration
+            )
+        )
+    if end is not None:
+        end = str(
+            video.convert_integer_seconds_to_natural_number(
+                end, duration
+            )
+        )
+
     if use_moviepy:
         edit_moviepy(joined_src_path, joined_dst_path, start, end,
                      moviepy_threads)

--- a/src/lib/view.py
+++ b/src/lib/view.py
@@ -135,9 +135,10 @@ def do_edit(
         return False
 
     start, end, edit_name = start_end_name_unpacker(tokens)
-    regex, format = r'[0-9]+', '[ natural number | timestamp in form <[hour]-min-sec> ]'
-    if integer:
-        regex, format = r'-?[0-9]+', '[ integer | timestamp in form <[hour]-min-sec> ]'
+    regex, format = r'-?[0-9]+', '[ integer | timestamp in form <[hour]-min-sec> ]'
+    # regex, format = r'[0-9]+', '[ natural number | timestamp in form <[hour]-min-sec> ]'
+    # if integer:
+    #     regex, format = r'-?[0-9]+', '[ integer | timestamp in form <[hour]-min-sec> ]'
 
     if not start is None:
         start = parse_time(start, regex, True, format, bold)
@@ -246,6 +247,10 @@ def check_times(
         if not check_in_bounds(
                 time, seconds, duration, base_name, bold, is_start=is_start):
             return False
+
+    with open('/tmp/a.txt', 'w') as f:
+        print(f'ss: {start_seconds}', file=f)
+        print(f'es: {end_seconds}', file=f)
 
     if not end_seconds > start_seconds:
         util.print_error(


### PR DESCRIPTION
Can now use middle command with negative timestamps.

Negative timestamps are stored in their original form.
But when they are either verified or used in computation, they are now switched to a natural number of seconds