### PR TITLE
Config constructor

### DIFF
--- a/mve/scripts/log/deleter.py
+++ b/mve/scripts/log/deleter.py
@@ -32,4 +32,3 @@ class Deleter(Legacy):
 
     def run_checks(self, state: config.Stateful):
         state.check_files_remaining()
-        state.cfg.no_source_folder()

--- a/mve/scripts/log/deleter.py
+++ b/mve/scripts/log/deleter.py
@@ -4,7 +4,7 @@ as the source folder will be mounted as a volume.'''
 
 import shutil
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.helpers.args as args
 import mve.src.helpers.colouring as colouring
@@ -19,7 +19,7 @@ class Deleter(Legacy):
         super().main(argv)
 
         name = args.expect_config_name(argv)
-        state = config.Stateful(name)
+        state = Stateful(name)
         self.run_checks(state)
 
         cfg = state.cfg
@@ -30,5 +30,5 @@ class Deleter(Legacy):
             colouring.highlight_path(cfg.folders.source, cfg.bold)
         ), cfg.bold)
 
-    def run_checks(self, state: config.Stateful):
+    def run_checks(self, state: Stateful):
         state.check_files_remaining()

--- a/mve/scripts/log/deleter.py
+++ b/mve/scripts/log/deleter.py
@@ -24,10 +24,10 @@ class Deleter(Legacy):
 
         cfg = state.cfg
 
-        files.do_folder_operation(cfg.source, shutil.rmtree)
+        files.do_folder_operation(cfg.folders.source, shutil.rmtree)
 
         util.exit_success('removed the folder \'{}\''.format(
-            colouring.highlight_path(cfg.source, cfg.bold)
+            colouring.highlight_path(cfg.folders.source, cfg.bold)
         ), cfg.bold)
 
     def run_checks(self, state: config.Stateful):

--- a/mve/scripts/log/generator.py
+++ b/mve/scripts/log/generator.py
@@ -43,7 +43,6 @@ class Generator(Legacy):
 
     def run_checks(self, state: config.Stateful):
         state.check_files_remaining()
-        state.cfg.no_source_folder()
 
     def good_file(self, file: str) -> bool:
         # ignore hidden files

--- a/mve/scripts/log/generator.py
+++ b/mve/scripts/log/generator.py
@@ -6,7 +6,7 @@ status error.FILES_REMAINING. If remaining JSON file does not exist, it is
 created. Files are stored from most recent to least recent. This behaviour can 
 be toggled through the RECENT config flag.'''
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.constants.video_editing as video_editing
 
@@ -23,7 +23,7 @@ class Generator(Legacy):
         super().main(argv)
 
         name = args.expect_config_name(argv)
-        state = config.Stateful(name)
+        state = Stateful(name)
         self.run_checks(state)
 
         cfg = state.cfg
@@ -41,7 +41,7 @@ class Generator(Legacy):
                 colouring.highlight(joined_path, cfg.bold), state.remaining),
             cfg.bold)
 
-    def run_checks(self, state: config.Stateful):
+    def run_checks(self, state: Stateful):
         state.check_files_remaining()
 
     def good_file(self, file: str) -> bool:

--- a/mve/scripts/log/generator.py
+++ b/mve/scripts/log/generator.py
@@ -30,12 +30,12 @@ class Generator(Legacy):
 
         new_files = list(
             filter(
-                self.good_file, files.ls(cfg.source, recent=cfg.recent)
+                self.good_file, files.ls(cfg.folders.source, recent=cfg.recent)
             )
         )
         state.write_remaining(new_files)
 
-        joined_path = files.join_folder(cfg.source)
+        joined_path = files.join_folder(cfg.folders.source)
         util.exit_success(
             'placed file names from the folder \'{}\' in {}'.format(
                 colouring.highlight(joined_path, cfg.bold), state.remaining),

--- a/mve/scripts/log/integrity.py
+++ b/mve/scripts/log/integrity.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import sys
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.constants.colours as colours
 import mve.src.constants.defaults as defaults
@@ -84,7 +84,7 @@ class Integrity(Script):
         )
 
     def check_one_config(self, config_paths: list[str], name: str, dirty: bool):
-        state = config.Stateful(name)
+        state = Stateful(name)
         bold = state.cfg.bold
         if not dirty:
             print(
@@ -112,11 +112,11 @@ class Integrity(Script):
             return display_message()
 
         depth += 1
-        for folder in config.Stateful.locate_folders(current_config):
+        for folder in Stateful.locate_folders(current_config):
             if self.check_folder(message, folder, folder[-1], depth):
                 return display_message()
 
-        for file in config.Stateful.locate_files(current_config):
+        for file in Stateful.locate_files(current_config):
             if self.check_file(message, file, os.path.basename(file), depth):
                 return display_message()
 

--- a/mve/scripts/log/make.py
+++ b/mve/scripts/log/make.py
@@ -11,7 +11,7 @@ import os
 import re
 import sys
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.constants.error as error
 import mve.src.constants.defaults as defaults
@@ -32,7 +32,7 @@ class Make(Script):
         name = args.config
         self.verify_name(name)
 
-        configs_folder = config.Stateful.locate_configs_folder()
+        configs_folder = Stateful.locate_configs_folder()
         new_config = configs_folder + [name]
         self.check_config_exists(new_config, name)
         self.make_config_folder(new_config)
@@ -77,11 +77,11 @@ class Make(Script):
 
     def write_config_to_file(self, new_config: list[str], source: None | str,
                              edits: None | str, renames: None | str):
-        for folder in config.Stateful.locate_folders(new_config):
+        for folder in Stateful.locate_folders(new_config):
             files.do_folder_operation(folder, os.mkdir)
             self.add_folder_to_version_history(folder)
 
-        config_file, remaining = config.Stateful.locate_files(new_config)
+        config_file, remaining = Stateful.locate_files(new_config)
         # write an empty list of remaining videos
         json_handlers.write_to_json(list(), remaining)
         folders = VideoPaths.make_all_paths_from_defaults(source,

--- a/mve/scripts/log/make.py
+++ b/mve/scripts/log/make.py
@@ -11,7 +11,7 @@ import os
 import re
 import sys
 
-from mve.src.config import Stateful
+from mve.src.config import Config, Stateful
 
 import mve.src.constants.error as error
 import mve.src.constants.defaults as defaults
@@ -85,8 +85,8 @@ class Make(Script):
         # write an empty list of remaining videos
         json_handlers.write_to_json(list(), remaining)
         folders = VideoPaths.make_all_paths_from_defaults(source,
-                                                                      edits,
-                                                                      renames)
+                                                          edits,
+                                                          renames)
         # the config will be created with default options
-        cfg = config.Config(folders)
+        cfg = Config(folders)
         cfg.write_config_to_file(config_file)

--- a/mve/scripts/log/make.py
+++ b/mve/scripts/log/make.py
@@ -21,7 +21,7 @@ import mve.src.helpers.colouring as colouring
 import mve.src.helpers.files as files
 import mve.src.helpers.json_handlers as json_handlers
 import mve.src.helpers.util as util
-import mve.src.helpers.video_paths as video_paths
+from mve.src.helpers.video_paths import VideoPaths
 
 from mve.scripts.script import Script
 
@@ -84,7 +84,7 @@ class Make(Script):
         config_file, remaining = config.Stateful.locate_files(new_config)
         # write an empty list of remaining videos
         json_handlers.write_to_json(list(), remaining)
-        folders = video_paths.VideoPaths.make_all_paths_from_defaults(source,
+        folders = VideoPaths.make_all_paths_from_defaults(source,
                                                                       edits,
                                                                       renames)
         # the config will be created with default options

--- a/mve/scripts/log/make.py
+++ b/mve/scripts/log/make.py
@@ -84,8 +84,9 @@ class Make(Script):
         config_file, remaining = config.Stateful.locate_files(new_config)
         # write an empty list of remaining videos
         json_handlers.write_to_json(list(), remaining)
-        videos = video_paths.VideoPaths.make_all_paths_from_defaults(source, edits,
-                                                                     renames)
+        folders = video_paths.VideoPaths.make_all_paths_from_defaults(source,
+                                                                      edits,
+                                                                      renames)
         # the config will be created with default options
-        cfg = config.Config(videos.source, videos.renames, videos.edits)
+        cfg = config.Config(folders)
         cfg.write_config_to_file(config_file)

--- a/mve/scripts/log/treater.py
+++ b/mve/scripts/log/treater.py
@@ -42,7 +42,7 @@ class Treater(Legacy):
         current_file = self.dequeue(state)
         joined_current_file = files.get_joined_path(state.queue, current_file)
         data = json_handlers.read_from_json(joined_current_file)
-        folders = cfg.create_source_folders()
+        folders = cfg.folders
 
         edit.treat_all(
             data,

--- a/mve/scripts/log/treater.py
+++ b/mve/scripts/log/treater.py
@@ -11,7 +11,7 @@ if any of the aformentioned folders do not exist.'''
 import os
 import sys
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.constants.error as error
 import mve.src.constants.errors_format as errors_format
@@ -33,7 +33,7 @@ class Treater(Legacy):
         super().main(argv)
 
         name = args.expect_config_name(argv)
-        state = config.Stateful(name)
+        state = Stateful(name)
         self.run_checks(state)
 
         cfg = state.cfg
@@ -58,26 +58,26 @@ class Treater(Legacy):
 
         util.exit_treat_all_good(cfg.bold)
 
-    def run_checks(self, state: config.Stateful):
+    def run_checks(self, state: Stateful):
         self.check_empty_queue(state)
 
-    def check_empty_queue(self, state: config.Stateful):
+    def check_empty_queue(self, state: Stateful):
         if not files.ls(state.queue):
             print(f'there are no files queued in folder \'{state.queue}\'')
             sys.exit(error.EMPTY_QUEUE)
 
-    def dequeue(self, state: config.Stateful):
+    def dequeue(self, state: Stateful):
         queue_files = files.ls(state.queue, recent=True)
         return queue_files[0]
 
     def update_history(self,
-                       state: config.Stateful, current_file: str,
+                       state: Stateful, current_file: str,
                        joined_current_file: str):
         joined_history_file = files.get_joined_path(
             state.history, current_file)
         os.rename(joined_current_file, joined_history_file)
 
-    def handle_errors(self, state: config.Stateful, remaining: list[str],
+    def handle_errors(self, state: Stateful, remaining: list[str],
                       errors: list[dict], paths_dict: dict[str, list[str]],
                       bold: bool):
         error_file_name = timestamps.generate_timestamped_file_name()
@@ -85,7 +85,7 @@ class Treater(Legacy):
         state.write_remaining(remaining)
         self.exit_treatment_error(error_file_name, bold)
 
-    def write_errors(self, state: config.Stateful, error_file_name: str,
+    def write_errors(self, state: Stateful, error_file_name: str,
                      errors: list[dict], paths_dict: dict[str, list[str]]
                      ):
         joined_error_file_name = files.get_joined_path(

--- a/mve/scripts/log/treater.py
+++ b/mve/scripts/log/treater.py
@@ -60,7 +60,6 @@ class Treater(Legacy):
 
     def run_checks(self, state: config.Stateful):
         self.check_empty_queue(state)
-        state.cfg.one_of_config_folders_missing()
 
     def check_empty_queue(self, state: config.Stateful):
         if not files.ls(state.queue):

--- a/mve/scripts/log/treater.py
+++ b/mve/scripts/log/treater.py
@@ -53,7 +53,7 @@ class Treater(Legacy):
         self.update_history(state, current_file, joined_current_file)
 
         if errors:
-            paths_dict = cfg.generate_paths_dict()
+            paths_dict = cfg.folders.generate_paths_dict()
             self.handle_errors(state, remaining, errors, paths_dict, cfg.bold)
 
         util.exit_treat_all_good(cfg.bold)

--- a/mve/scripts/log/viewer.py
+++ b/mve/scripts/log/viewer.py
@@ -7,7 +7,7 @@ hosted by the container. The viewer will prematurely terminate if there are no
 remaining files, or the source folder for the given config does not exist.
 Once complete, the viewer enques a new treatment for the given config.'''
 
-import mve.src.config as config
+from mve.src.config import Stateful
 
 import mve.src.constants.treatment_format as treatment_format
 
@@ -27,7 +27,7 @@ class Viewer(Legacy):
         super().main(argv)
 
         name = args.expect_config_name(argv)
-        state = config.Stateful(name)
+        state = Stateful(name)
 
         cfg = state.cfg
 
@@ -46,7 +46,7 @@ class Viewer(Legacy):
         util.exit_success(
             util.format_remaining(len(remaining), cfg.bold), cfg.bold)
 
-    def log_to_file(self, state: config.Stateful, edits: list[dict],
+    def log_to_file(self, state: Stateful, edits: list[dict],
                     renames: dict[str, str], deletions: list[str],
                     paths_dict: dict[str, list[str]]):
         treatment_name = timestamps.generate_timestamped_file_name()

--- a/mve/scripts/log/viewer.py
+++ b/mve/scripts/log/viewer.py
@@ -40,7 +40,7 @@ class Viewer(Legacy):
         state.write_remaining(remaining)
 
         if edits or renames or deletions:
-            paths_dict = cfg.generate_paths_dict()
+            paths_dict = cfg.folders.generate_paths_dict()
             self.log_to_file(state, edits, renames, deletions, paths_dict)
 
         util.exit_success(

--- a/mve/scripts/log/viewer.py
+++ b/mve/scripts/log/viewer.py
@@ -34,7 +34,7 @@ class Viewer(Legacy):
 
         remaining = state.load_remaining()
         edits, renames, deletions = list(), dict(), list()
-        folders = cfg.create_source_folders()
+        folders = cfg.folders
         view.run_loop(
             remaining, edits, renames, deletions, folders, cfg.testing, cfg.bold,
             cfg.verify_name)

--- a/mve/scripts/log/viewer.py
+++ b/mve/scripts/log/viewer.py
@@ -28,7 +28,6 @@ class Viewer(Legacy):
 
         name = args.expect_config_name(argv)
         state = config.Stateful(name)
-        self.run_checks(state.cfg)
 
         cfg = state.cfg
 
@@ -46,9 +45,6 @@ class Viewer(Legacy):
 
         util.exit_success(
             util.format_remaining(len(remaining), cfg.bold), cfg.bold)
-
-    def run_checks(self, cfg: config.Config):
-        cfg.one_of_config_folders_missing()
 
     def log_to_file(self, state: config.Stateful, edits: list[dict],
                     renames: dict[str, str], deletions: list[str],

--- a/mve/scripts/no_log/focus.py
+++ b/mve/scripts/no_log/focus.py
@@ -32,10 +32,10 @@ from mve.scripts.script import Script
 
 class Focus(Script):
     def main(self, argv: list[str]) -> None:
-        source, paths = self.make_source_and_paths(argv, defaults.BOLD)
+        source, folders = self.make_source_and_paths(argv, defaults.BOLD)
 
         # edit information
-        cfg = config.Config(paths.source, paths.renames, paths.edits)
+        cfg = config.Config(folders)
         edits, errors = [], []
 
         while True:
@@ -47,13 +47,13 @@ class Focus(Script):
 
             try:
                 start, end, name = self.parse_and_validate_tokens(
-                    tokens, cfg.bold, paths.edits)
+                    tokens, cfg.bold, folders.edits)
                 view.log_edit(source, name, edits, start, end)
             except self.BadTokenException:
                 print('format: [q]uit, or <start> <end> [name]')
                 continue
 
-        self.finish_program(edits, errors, cfg, paths, cfg.bold)
+        self.finish_program(edits, errors, cfg, folders, cfg.bold)
 
     def make_source_and_paths(self, argv: list[str],
                               bold: bool) -> tuple[str, video_paths.VideoPaths]:

--- a/mve/scripts/no_log/focus.py
+++ b/mve/scripts/no_log/focus.py
@@ -21,7 +21,7 @@ import mve.src.constants.json_settings as json_settings
 
 import mve.src.helpers.colouring as colouring
 import mve.src.helpers.util as util
-import mve.src.helpers.video_paths as video_paths
+from mve.src.helpers.video_paths import VideoPaths
 
 import mve.src.lib.edit as edit
 import mve.src.lib.view as view
@@ -56,7 +56,7 @@ class Focus(Script):
         self.finish_program(edits, errors, cfg, folders, cfg.bold)
 
     def make_source_and_paths(self, argv: list[str],
-                              bold: bool) -> tuple[str, video_paths.VideoPaths]:
+                              bold: bool) -> tuple[str, VideoPaths]:
         parser: argparse.ArgumentParser = argparse.ArgumentParser()
         parser.add_argument('source', type=str)
         parser.add_argument(
@@ -76,7 +76,7 @@ class Focus(Script):
         source_folder: list[str] = list(source_path.parent.parts)
         destination_folder: list[str] = list(
             pathlib.Path(args.destination).parts)
-        return source_path.name, video_paths.VideoPaths(source_folder,
+        return source_path.name, VideoPaths(source_folder,
                                                         destination_folder,
                                                         destination_folder)
 
@@ -132,7 +132,7 @@ class Focus(Script):
         return start_seconds, end_seconds, edit_name
 
     def finish_program(self, edits: list, errors: list, cfg: config.Config,
-                       paths: video_paths.VideoPaths, bold: bool):
+                       paths: VideoPaths, bold: bool):
         self.print_number_edits(
             len(edits), bold
         )
@@ -148,7 +148,7 @@ class Focus(Script):
         )
 
     def edit_files(self, edits: list, errors: list, cfg: config.Config,
-                   paths: video_paths.VideoPaths):
+                   paths: VideoPaths):
         # Queue stored in memory, not written to disk
         # Then when you quit, edits are performed.
         data = view.wrap_session(edits, {}, [])
@@ -176,9 +176,9 @@ class Focus(Script):
         source_path: pathlib.Path = pathlib.Path(source)
         return source_path.name, list(source_path.parent.parts)
 
-    def create_paths(self, source_parent: list[str]) -> video_paths.VideoPaths:
+    def create_paths(self, source_parent: list[str]) -> VideoPaths:
         destination: list[str] = self.locate_destination_folder()
-        return video_paths.VideoPaths(
+        return VideoPaths(
             source_parent, destination, destination)
 
     def locate_destination_folder(self, ) -> list[str]:

--- a/mve/scripts/no_log/focus.py
+++ b/mve/scripts/no_log/focus.py
@@ -12,7 +12,7 @@ import os
 import pathlib
 import sys
 
-import mve.src.config as config
+from mve.src.config import Config
 
 import mve.src.constants.colours as colours
 import mve.src.constants.defaults as defaults
@@ -35,7 +35,7 @@ class Focus(Script):
         source, folders = self.make_source_and_paths(argv, defaults.BOLD)
 
         # edit information
-        cfg = config.Config(folders)
+        cfg = Config(folders)
         edits, errors = [], []
 
         while True:
@@ -77,8 +77,8 @@ class Focus(Script):
         destination_folder: list[str] = list(
             pathlib.Path(args.destination).parts)
         return source_path.name, VideoPaths(source_folder,
-                                                        destination_folder,
-                                                        destination_folder)
+                                            destination_folder,
+                                            destination_folder)
 
     class BadTokenException(Exception):
         pass
@@ -131,7 +131,7 @@ class Focus(Script):
 
         return start_seconds, end_seconds, edit_name
 
-    def finish_program(self, edits: list, errors: list, cfg: config.Config,
+    def finish_program(self, edits: list, errors: list, cfg: Config,
                        paths: VideoPaths, bold: bool):
         self.print_number_edits(
             len(edits), bold
@@ -147,7 +147,7 @@ class Focus(Script):
             )
         )
 
-    def edit_files(self, edits: list, errors: list, cfg: config.Config,
+    def edit_files(self, edits: list, errors: list, cfg: Config,
                    paths: VideoPaths):
         # Queue stored in memory, not written to disk
         # Then when you quit, edits are performed.

--- a/mve/scripts/no_log/moment.py
+++ b/mve/scripts/no_log/moment.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import sys
 
-import mve.src.config as config
+from mve.src.config import Config
 
 import mve.src.constants.error as error
 import mve.src.constants.json_settings as json_settings
@@ -30,7 +30,7 @@ class Moment(Script):
 
         folders = VideoPaths.make_merged_dest_from_defaults(
             source, dest)
-        cfg = config.Config(folders)
+        cfg = Config(folders)
 
         self.configure_settings(cfg, args.testing)
 
@@ -88,7 +88,7 @@ class Moment(Script):
         path: pathlib.Path = pathlib.Path(abs_path)
         return list(path.parts)
 
-    def configure_settings(self, cfg: config.Config, testing: bool):
+    def configure_settings(self, cfg: Config, testing: bool):
         cfg.recent = False
         cfg.testing = testing
         cfg.verify_name = False

--- a/mve/scripts/no_log/moment.py
+++ b/mve/scripts/no_log/moment.py
@@ -28,16 +28,16 @@ class Moment(Script):
         args = self.handle_args(argv)
         source, dest = self.get_paths_from_args(args)
 
-        paths = video_paths.VideoPaths.make_merged_dest_from_defaults(
+        folders = video_paths.VideoPaths.make_merged_dest_from_defaults(
             source, dest)
-        cfg = config.Config(paths.source, paths.renames, paths.edits)
+        cfg = config.Config(folders)
 
         self.configure_settings(cfg, args.testing)
 
-        remaining, errors = self.gen_remaining(paths, cfg.recent), list()
+        remaining, errors = self.gen_remaining(folders, cfg.recent), list()
         edits, renames, deletions = list(), dict(), list()
         num_remaining = view.run_loop(remaining, edits, renames,
-                                      deletions, paths, cfg.testing, cfg.bold,
+                                      deletions, folders, cfg.testing, cfg.bold,
                                       cfg.verify_name)
         data = view.wrap_session(edits, renames, deletions)
         print(
@@ -45,7 +45,7 @@ class Moment(Script):
         )
 
         edit.treat_all(data, cfg.use_moviepy, cfg.moviepy_threads,
-                       cfg.num_processes, remaining, errors, paths)
+                       cfg.num_processes, remaining, errors, folders)
         self.handle_errors(errors, cfg.bold)
         util.exit_treat_all_good(cfg.bold)
 

--- a/mve/scripts/no_log/moment.py
+++ b/mve/scripts/no_log/moment.py
@@ -13,7 +13,7 @@ import mve.src.constants.error as error
 import mve.src.constants.json_settings as json_settings
 
 import mve.src.helpers.files as files
-import mve.src.helpers.video_paths as video_paths
+from mve.src.helpers.video_paths import VideoPaths
 import mve.src.helpers.util as util
 
 import mve.src.lib.view as view
@@ -28,7 +28,7 @@ class Moment(Script):
         args = self.handle_args(argv)
         source, dest = self.get_paths_from_args(args)
 
-        folders = video_paths.VideoPaths.make_merged_dest_from_defaults(
+        folders = VideoPaths.make_merged_dest_from_defaults(
             source, dest)
         cfg = config.Config(folders)
 
@@ -81,7 +81,7 @@ class Moment(Script):
         return source, dest
 
     def gen_remaining(
-            self, paths: video_paths.VideoPaths, recent: bool) -> list[str]:
+            self, paths: VideoPaths, recent: bool) -> list[str]:
         return files.ls(paths.source, recent=recent)
 
     def decompose_path_into_folders(self, abs_path: str) -> list[str]:

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -58,9 +58,9 @@ class Config():
     def write_config_to_file(self, joined_destination_path: str):
         data = {
             # folders
-            options.SOURCE: self.source,
-            options.RENAMES: self.renames,
-            options.DESTINATION: self.destination,
+            options.SOURCE: self.folders.source,
+            options.RENAMES: self.folders.renames,
+            options.DESTINATION: self.folders.edits,
 
             # file-order generation
             options.RECENT: self.recent,
@@ -189,6 +189,7 @@ class Stateful():
         destination: list[str] = Stateful.expect_paths_list(
             contents, options.DESTINATION, error.CONFIG_MISSING_DESTINATION,
             bold)
+        folders = video_paths.VideoPaths(source, destination, renames)
 
         # file-order generation
         recent = contents.get(options.RECENT, defaults.RECENT)
@@ -206,8 +207,7 @@ class Stateful():
         testing: bool = contents.get(options.TESTING, defaults.TESTING)
 
         return Config(
-            # folders
-            source, renames, destination,
+            folders,
             # options
             recent,
             num_processes,

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -22,8 +22,8 @@ class Config():
 
     def __init__(
         self,
-        # folders
-        source: list[str], renames: list[str], destination: list[str],
+        folders: video_paths.VideoPaths,
+
         # options
         recent: bool = defaults.RECENT,
         num_processes: int = defaults.NUM_PROCESSES,
@@ -33,10 +33,7 @@ class Config():
         bold: bool = defaults.BOLD,
         verify_name: bool = defaults.VERIFY_NAME
     ):
-        # folders
-        self.source: list[str] = source
-        self.renames: list[str] = renames
-        self.destination: list[str] = destination
+        self.folders: video_paths.VideoPaths = folders
 
         # file-order generation
         self.recent: bool = recent
@@ -72,10 +69,6 @@ class Config():
                 error.NO_DESTINATION_FOLDER]
         ):
             check_and_exit_if.no_folder(folder, desc, self.bold, code)
-
-    def create_source_folders(self) -> video_paths.VideoPaths:
-        return video_paths.VideoPaths(
-            self.source, self.destination, self.renames)
 
     def generate_paths_dict(self) -> dict[str, list[str]]:
         return {

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -1,7 +1,5 @@
 '''Configure folder paths and settings for a given category of videos.'''
 
-import os
-import pathlib
 import sys
 
 import mve.src.constants.defaults as defaults

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -5,7 +5,6 @@ import sys
 import mve.src.constants.defaults as defaults
 import mve.src.constants.error as error
 import mve.src.constants.options as options
-import mve.src.constants.treatment_format as treatment_format
 
 import mve.src.helpers.check_and_exit_if as check_and_exit_if
 import mve.src.helpers.files as files

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -55,13 +55,6 @@ class Config():
         # double-check name was not mistaken for a command
         self.verify_name: bool = verify_name
 
-    def generate_paths_dict(self) -> dict[str, list[str]]:
-        return {
-            treatment_format.SOURCE_PATH: self.source,
-            treatment_format.RENAME_PATH: self.renames,
-            treatment_format.DESTINATION_PATH: self.destination
-        }
-
     def write_config_to_file(self, joined_destination_path: str):
         data = {
             # folders

--- a/mve/src/config.py
+++ b/mve/src/config.py
@@ -23,7 +23,6 @@ class Config():
     def __init__(
         self,
         folders: video_paths.VideoPaths,
-
         # options
         recent: bool = defaults.RECENT,
         num_processes: int = defaults.NUM_PROCESSES,
@@ -33,6 +32,7 @@ class Config():
         bold: bool = defaults.BOLD,
         verify_name: bool = defaults.VERIFY_NAME
     ):
+        folders.verify_paths_integrity()
         self.folders: video_paths.VideoPaths = folders
 
         # file-order generation
@@ -54,21 +54,6 @@ class Config():
 
         # double-check name was not mistaken for a command
         self.verify_name: bool = verify_name
-
-    # folder existence checking
-
-    def no_source_folder(self):
-        check_and_exit_if.no_folder(
-            self.source, 'source', self.bold, error.NO_SOURCE_FOLDER, )
-
-    def one_of_config_folders_missing(self):
-        for folder, desc, code in zip(
-            [self.source, self.renames, self.destination],
-            ['source', 'renames', 'destination'],
-            [error.NO_SOURCE_FOLDER, error.NO_RENAMES_FOLDER,
-                error.NO_DESTINATION_FOLDER]
-        ):
-            check_and_exit_if.no_folder(folder, desc, self.bold, code)
 
     def generate_paths_dict(self) -> dict[str, list[str]]:
         return {

--- a/mve/src/constants/defaults.py
+++ b/mve/src/constants/defaults.py
@@ -1,3 +1,6 @@
+'''These defaults are used before a config has been successfully made by
+its constructor (ie. some constructor invariants might fail.'''
+
 # file-order generation
 RECENT: bool = False
 

--- a/mve/src/constants/json_settings.py
+++ b/mve/src/constants/json_settings.py
@@ -1,1 +1,1 @@
-INDENT_SPACES: str = 4
+INDENT_SPACES: int = 4

--- a/mve/src/helpers/video_paths.py
+++ b/mve/src/helpers/video_paths.py
@@ -1,3 +1,7 @@
+import mve.src.constants.error as error
+import mve.src.constants.defaults as defaults
+
+import mve.src.helpers.check_and_exit_if as check_and_exit_if
 import mve.src.helpers.files as files
 import mve.src.helpers.util as util
 
@@ -11,6 +15,16 @@ class VideoPaths:
         self.source: list[str] = source
         self.edits: list[str] = edits
         self.renames: list[str] = renames
+
+    def verify_paths_integrity(self):
+        '''Exit the program if one of the stored paths does not exist.'''
+        for folder, desc, code in zip(
+            [self.source, self.renames, self.edits],
+            ['source', 'renames', 'destination'],
+            [error.NO_SOURCE_FOLDER, error.NO_RENAMES_FOLDER,
+                error.NO_DESTINATION_FOLDER]
+        ):
+            check_and_exit_if.no_folder(folder, desc, defaults.BOLD, code)
 
     @staticmethod
     def make_all_paths_from_defaults(source: None | str, edits: None | str,

--- a/mve/src/helpers/video_paths.py
+++ b/mve/src/helpers/video_paths.py
@@ -1,5 +1,6 @@
 import mve.src.constants.error as error
 import mve.src.constants.defaults as defaults
+import mve.src.constants.treatment_format as treatment_format
 
 import mve.src.helpers.check_and_exit_if as check_and_exit_if
 import mve.src.helpers.files as files
@@ -25,6 +26,14 @@ class VideoPaths:
                 error.NO_DESTINATION_FOLDER]
         ):
             check_and_exit_if.no_folder(folder, desc, defaults.BOLD, code)
+
+    def generate_paths_dict(self) -> dict[str, list[str]]:
+        '''Generate the JSON dictionary for logging.'''
+        return {
+            treatment_format.SOURCE_PATH: self.source,
+            treatment_format.RENAME_PATH: self.renames,
+            treatment_format.DESTINATION_PATH: self.edits
+        }
 
     @staticmethod
     def make_all_paths_from_defaults(source: None | str, edits: None | str,

--- a/mve/src/lib/edit.py
+++ b/mve/src/lib/edit.py
@@ -11,13 +11,13 @@ import mve.src.constants.video_editing as video_editing
 import mve.src.helpers.files as files
 import mve.src.helpers.time_handlers as time_handlers
 import mve.src.helpers.video as video
-import mve.src.helpers.video_paths as video_paths
+from mve.src.helpers.video_paths import VideoPaths
 
 
 def treat_all(data: dict,
               use_moviepy: bool, moviepy_threads: int, num_processes: int,
               remaining: list[str], errors: list[dict],
-              paths: video_paths.VideoPaths):
+              paths: VideoPaths):
     edits = data[treatment_format.EDITS]
     edit_all(edits, use_moviepy, moviepy_threads,
              num_processes, remaining, errors, paths)
@@ -32,7 +32,7 @@ def treat_all(data: dict,
 def edit_all(
         edits: list[dict], use_moviepy: bool, moviepy_threads: int,
         num_processes: int, remaining: list[str], errors: list[dict],
-        paths: video_paths.VideoPaths):
+        paths: VideoPaths):
     with concurrent.futures.ProcessPoolExecutor(
             max_workers=num_processes) as executor:
         results = [executor.submit(
@@ -49,7 +49,7 @@ def edit_all(
 
 
 def edit_one(edit: dict, use_moviepy: bool, moviepy_threads: int,
-             paths: video_paths.VideoPaths):
+             paths: VideoPaths):
     name = edit[treatment_format.EDIT_ORIGINAL]
     joined_src_path = files.get_joined_path(paths.source, name)
     joined_dst_path = files.get_joined_path(
@@ -158,7 +158,7 @@ def add_to_remaining(remaining: list[str], name: str):
 
 def rename_all(
         renames: dict[str, str], remaining: list[str], errors: list[dict],
-        paths: video_paths.VideoPaths):
+        paths: VideoPaths):
     for rename_source in renames:
         new_name = renames[rename_source]
         try:
@@ -168,7 +168,7 @@ def rename_all(
                          str(e), treatment_format.RENAMES, new_name)
 
 
-def do_rename(src_name: str, dst_name: str, paths: video_paths.VideoPaths):
+def do_rename(src_name: str, dst_name: str, paths: VideoPaths):
     joined_src_name = files.get_joined_path(paths.source, src_name)
     joined_dst_name = files.get_joined_path(paths.renames, dst_name)
     os.rename(joined_src_name, joined_dst_name)
@@ -176,7 +176,7 @@ def do_rename(src_name: str, dst_name: str, paths: video_paths.VideoPaths):
 
 def delete_all(
         deletions: list[str], remaining: list[str], errors: list[dict],
-        paths: video_paths.VideoPaths):
+        paths: VideoPaths):
     for deletion_name in deletions:
         try:
             do_delete(deletion_name, paths)
@@ -185,6 +185,6 @@ def delete_all(
                          str(e), treatment_format.DELETIONS, None)
 
 
-def do_delete(src_name: str, paths: video_paths.VideoPaths):
+def do_delete(src_name: str, paths: VideoPaths):
     joined_src_name = files.get_joined_path(paths.source, src_name)
     os.remove(joined_src_name)

--- a/mve/src/lib/view.py
+++ b/mve/src/lib/view.py
@@ -14,7 +14,7 @@ import mve.src.constants.video_editing as video_editing
 import mve.src.helpers.util as util
 import mve.src.helpers.time_handlers as time_handlers
 import mve.src.helpers.video as video
-import mve.src.helpers.video_paths as video_paths
+from mve.src.helpers.video_paths import VideoPaths
 import mve.src.helpers.files as files
 import mve.src.helpers.colouring as colouring
 
@@ -22,7 +22,7 @@ import mve.src.helpers.colouring as colouring
 def run_loop(
         remaining: list[str],
         edits: list[dict], renames: dict[str, str], deletions: list[str],
-        paths: video_paths.VideoPaths, testing: bool, bold: bool,
+        paths: VideoPaths, testing: bool, bold: bool,
         verify_name: bool) -> int:
     padding = len(
         str(
@@ -73,7 +73,7 @@ def run_loop(
     return len(remaining)
 
 
-def view_video(base_name: str, testing: bool, paths: video_paths.VideoPaths):
+def view_video(base_name: str, testing: bool, paths: VideoPaths):
     if testing:
         return
 
@@ -121,7 +121,7 @@ def highlight_command(command: str, bold: bool) -> str:
 
 def do_end(
         base_name: str, raw_tokens: str, edits: list[dict],
-        paths: video_paths.VideoPaths, bold: bool, verify_name: bool) -> bool:
+        paths: VideoPaths, bold: bool, verify_name: bool) -> bool:
     return do_edit(
         commands.END, base_name, raw_tokens, edits,
         lambda tokens: (tokens[0], None, tokens[1]), paths, bold, verify_name)
@@ -132,7 +132,7 @@ def do_edit(
         start_end_name_unpacker: typing.Callable[
             # start and end optional, end mandatory
             [list[str]], tuple[None | str, None | str, str]],
-        paths: video_paths.VideoPaths, bold: bool, verify_name: bool
+        paths: VideoPaths, bold: bool, verify_name: bool
 ) -> bool:
     tokens = parse_tokens(raw_tokens, command, bold)
     if tokens is None:
@@ -221,7 +221,7 @@ def print_time_format(is_start: bool, format: str, bold: bool):
 
 def check_times(
         base_name: str, start: str, end: str,
-        paths: video_paths.VideoPaths, bold: bool) -> bool:
+        paths: VideoPaths, bold: bool) -> bool:
     if start is None and end is None:
         return True
 
@@ -378,7 +378,7 @@ def log_edit(
 
 def do_start(
         base_name: str, raw_tokens: str, edits: list[dict],
-        paths: video_paths.VideoPaths, bold: bool, verify_name: bool) -> bool:
+        paths: VideoPaths, bold: bool, verify_name: bool) -> bool:
     return do_edit(
         commands.START, base_name, raw_tokens, edits,
         lambda tokens: (None, tokens[0], tokens[1]), paths, bold, verify_name)
@@ -386,7 +386,7 @@ def do_start(
 
 def do_middle(
         base_name: str, raw_tokens: str, edits: list[dict],
-        paths: video_paths.VideoPaths, bold: bool, verify_name: bool) -> bool:
+        paths: VideoPaths, bold: bool, verify_name: bool) -> bool:
     return do_edit(
         commands.MIDDLE, base_name, raw_tokens, edits,
         lambda tokens: (tokens[0], tokens[1], tokens[2]), paths, bold,
@@ -395,7 +395,7 @@ def do_middle(
 
 def do_whole(
         base_name: str, raw_tokens: str, edits: list[dict],
-        paths: video_paths.VideoPaths, bold: bool, verify_name: bool) -> bool:
+        paths: VideoPaths, bold: bool, verify_name: bool) -> bool:
     return do_edit(
         commands.WHOLE, base_name, raw_tokens, edits,
         lambda tokens: (None, None, tokens[0]), paths, bold, verify_name)
@@ -403,7 +403,7 @@ def do_whole(
 
 def do_rename(
         base_name: str, raw_tokens: str, renames: dict[str, str],
-        paths: video_paths.VideoPaths, bold: bool) -> bool:
+        paths: VideoPaths, bold: bool) -> bool:
     tokens = parse_tokens(raw_tokens, commands.RENAME, bold)
     if not tokens:
         return False


### PR DESCRIPTION
Changing imports of classes to use `from` syntax for clarity.
`Config` now uses composition of `VideoPaths`, and all path-related management is delegated there.